### PR TITLE
Add single-file Minesweeper game

### DIFF
--- a/minesweeper.html
+++ b/minesweeper.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Minesweeper</title>
+<style>
+  body {
+    font-family: Arial, sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 20px;
+  }
+  #board {
+    display: grid;
+    grid-template-columns: repeat(9, 30px);
+    grid-template-rows: repeat(9, 30px);
+    gap: 2px;
+  }
+  .cell {
+    width: 30px;
+    height: 30px;
+    background: #bbb;
+    border: 1px solid #888;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    font-weight: bold;
+    user-select: none;
+  }
+  .cell.revealed {
+    background: #e0e0e0;
+    cursor: default;
+  }
+  .cell.mine {
+    background: #e57373;
+  }
+  .cell.flagged::after {
+    content: '\1F6A9';
+  }
+  #controls {
+    margin-bottom: 10px;
+  }
+</style>
+</head>
+<body>
+<div id="controls">
+  <button id="restart">Restart</button>
+</div>
+<div id="board"></div>
+<script>
+const rows = 9;
+const cols = 9;
+const minesCount = 10;
+let board = [];
+let gameOver = false;
+
+function init() {
+  const boardEl = document.getElementById('board');
+  boardEl.innerHTML = '';
+  board = [];
+  gameOver = false;
+
+  // Build board
+  for (let r = 0; r < rows; r++) {
+    const row = [];
+    for (let c = 0; c < cols; c++) {
+      const cellEl = document.createElement('div');
+      cellEl.className = 'cell';
+      cellEl.dataset.row = r;
+      cellEl.dataset.col = c;
+      cellEl.addEventListener('click', onLeftClick);
+      cellEl.addEventListener('contextmenu', onRightClick);
+      boardEl.appendChild(cellEl);
+      row.push({ mine: false, revealed: false, flagged: false, adjacent: 0, el: cellEl });
+    }
+    board.push(row);
+  }
+
+  // Place mines
+  let placed = 0;
+  while (placed < minesCount) {
+    const r = Math.floor(Math.random() * rows);
+    const c = Math.floor(Math.random() * cols);
+    if (board[r][c].mine) continue;
+    board[r][c].mine = true;
+    placed++;
+    for (let dr = -1; dr <= 1; dr++) {
+      for (let dc = -1; dc <= 1; dc++) {
+        const nr = r + dr;
+        const nc = c + dc;
+        if (nr >= 0 && nr < rows && nc >= 0 && nc < cols) {
+          board[nr][nc].adjacent++;
+        }
+      }
+    }
+  }
+}
+
+function onLeftClick(e) {
+  const r = parseInt(this.dataset.row);
+  const c = parseInt(this.dataset.col);
+  const cell = board[r][c];
+  if (gameOver || cell.flagged || cell.revealed) return;
+  if (cell.mine) {
+    this.classList.add('mine');
+    revealMines();
+    gameOver = true;
+    alert('Game Over');
+    return;
+  }
+  reveal(r, c);
+  checkWin();
+}
+
+function onRightClick(e) {
+  e.preventDefault();
+  const r = parseInt(this.dataset.row);
+  const c = parseInt(this.dataset.col);
+  const cell = board[r][c];
+  if (gameOver || cell.revealed) return;
+  cell.flagged = !cell.flagged;
+  this.classList.toggle('flagged');
+}
+
+function reveal(r, c) {
+  const cell = board[r][c];
+  if (cell.revealed || cell.flagged) return;
+  cell.revealed = true;
+  cell.el.classList.add('revealed');
+  if (cell.adjacent > 0) {
+    cell.el.textContent = cell.adjacent;
+    return;
+  }
+  for (let dr = -1; dr <= 1; dr++) {
+    for (let dc = -1; dc <= 1; dc++) {
+      const nr = r + dr;
+      const nc = c + dc;
+      if (nr >= 0 && nr < rows && nc >= 0 && nc < cols) {
+        reveal(nr, nc);
+      }
+    }
+  }
+}
+
+function revealMines() {
+  for (const row of board) {
+    for (const cell of row) {
+      if (cell.mine) {
+        cell.el.classList.add('mine');
+      }
+    }
+  }
+}
+
+function checkWin() {
+  for (const row of board) {
+    for (const cell of row) {
+      if (!cell.mine && !cell.revealed) {
+        return;
+      }
+    }
+  }
+  gameOver = true;
+  alert('You win!');
+}
+
+document.getElementById('restart').addEventListener('click', init);
+window.addEventListener('load', init);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Implement a self-contained Minesweeper game in one HTML file with inline CSS and JavaScript.
- Includes grid generation, mine placement, cell reveal, flagging, and win/loss detection with restart control.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b11ba3095c83269d2b90070121874a