### PR TITLE
fix: hide control hint during gameplay

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,6 +167,10 @@
       /* Header help button */
       .help-btn { cursor: pointer; }
 
+      body.playing header .controls {
+        display: none;
+      }
+
       footer {
         color: var(--muted);
         text-align: center;
@@ -177,7 +181,7 @@
     <div class="wrap">
       <header>
         <div class="pill">Snake — single HTML file</div>
-        <div class="pill">Arrow keys / WASD · Space: Pause · R: Restart</div>
+        <div class="pill controls">Arrow keys / WASD · Space: Pause · R: Restart</div>
         <div class="stats">
           <div class="badge" id="score">Score: 0</div>
           <div class="badge" id="best">Best: 0</div>


### PR DESCRIPTION
## Summary
- hide on-screen control instructions when the game is active

## Testing
- `python -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_68b11cbf7c308326b45d823d0e23caaa